### PR TITLE
Add CORS support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,7 @@
 source 'https://rubygems.org'
 gem 'sinatra'
 gem 'sinatra-contrib'
+gem 'sinatra-cors'
 gem 'haml', "~> 4.0"
 # gem 'geocollider', :path => '/Users/ryan/source/dc3/geocollider'
 gem 'geocollider', :git => 'https://github.com/isawnyu/geocollider.git'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -84,6 +84,7 @@ GEM
       rack-protection (= 2.0.8.1)
       sinatra (= 2.0.8.1)
       tilt (~> 2.0)
+    sinatra-cors (1.1.0)
     sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -117,6 +118,7 @@ DEPENDENCIES
   sass
   sinatra
   sinatra-contrib
+  sinatra-cors
   sprockets
   sucker_punch
   uglifier

--- a/geocollider-sinatra.rb
+++ b/geocollider-sinatra.rb
@@ -5,6 +5,7 @@ Encoding.default_internal = Encoding::UTF_8
 
 require 'sinatra/base'
 require 'sinatra/json'
+require 'sinatra/cors'
 require 'sinatra/multi_route'
 require 'tempfile'
 require 'haml'
@@ -59,6 +60,11 @@ end
 class GeocolliderSinatra < Sinatra::Base
   helpers Sinatra::Jsonp
   register Sinatra::MultiRoute
+  register Sinatra::Cors
+
+  set :allow_origin, "*"
+  set :allow_methods, "GET,HEAD,POST"
+  set :allow_headers, "Origin, Accept, Content-Type, X-Requested-With, X-CSRF-Token"
 
   LATITUDE_PID = 'http://www.w3.org/2003/01/geo/wgs84_pos#lat'
   LONGITUDE_PID = 'http://www.w3.org/2003/01/geo/wgs84_pos#long'


### PR DESCRIPTION
Hi! Thanks for maintaining this reconciliation endpoint.

We (the [Reconciliation CG](https://www.w3.org/community/reconciliation/)) are trying to revamp this API, and as part of that we are trying to encourage migration to CORS instead of JSONP. See the corresponding issue: https://github.com/reconciliation-api/specs/issues/19

This PR *should* add CORS support to your reconciliation endpoint, although I have not tested it (as I don't do Ruby).